### PR TITLE
use wildcard dev profile for debug

### DIFF
--- a/VRadventure0/VRadventure0.xcodeproj/project.pbxproj
+++ b/VRadventure0/VRadventure0.xcodeproj/project.pbxproj
@@ -99,7 +99,8 @@
 				TargetAttributes = {
 					CB849C901D664A5A00A3860C = {
 						CreatedOnToolsVersion = 8.0;
-						ProvisioningStyle = Automatic;
+						DevelopmentTeam = PBH8V487HB;
+						ProvisioningStyle = Manual;
 					};
 				};
 			};
@@ -262,11 +263,13 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
-				DEVELOPMENT_TEAM = "";
+				DEVELOPMENT_TEAM = PBH8V487HB;
 				INFOPLIST_FILE = VRadventure0/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.robotsandpencils.VRadventure0;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE = "f5dd99b6-f316-4243-87af-c33fb944972b";
+				PROVISIONING_PROFILE_SPECIFIER = "Dev Wildcard";
 				SWIFT_VERSION = 3.0;
 			};
 			name = Debug;


### PR DESCRIPTION
Added the R&P Wildcard dev profile so that the project (which falls under the `com.robotsandpencils.*` wildcard) can be built and run on a physical device.

This may or may not be appropriate depending on how you want others (who may not have access to the wildcard dev profile) to be able to build and run this project on their own device.
